### PR TITLE
Handle InAppBrowser exit event correctly

### DIFF
--- a/src/session.js
+++ b/src/session.js
@@ -1,18 +1,23 @@
 function Session() {}
 
 Session.clean = function () {
-  Session.current = function () { return false; };
+    Session.current = function () { return false; };
+    Session.isClosing = false;
+};
+
+Session.closing = function () {
+    Session.isClosing = true;
 };
 
 Session.start = function (handler) {
-  Session.current(new Error('Only one instance of auth can happen at a time'));
-  Session.current = handler;
+    Session.current(new Error('Only one instance of auth can happen at a time'));
+    Session.current = handler;
 };
 
 Session.onRedirectUri = function (url) {
-  if (Session.current(null, url)) {
-    Session.clean();
-  }
+    if (Session.current(null, url)) {
+        Session.clean();
+    }
 };
 
 module.exports = Session;

--- a/src/session.js
+++ b/src/session.js
@@ -1,23 +1,23 @@
 function Session() {}
 
 Session.clean = function () {
-    Session.current = function () { return false; };
-    Session.isClosing = false;
+  Session.current = function () { return false; };
+  Session.isClosing = false;
 };
 
 Session.closing = function () {
-    Session.isClosing = true;
+  Session.isClosing = true;
 };
 
 Session.start = function (handler) {
-    Session.current(new Error('Only one instance of auth can happen at a time'));
-    Session.current = handler;
+  Session.current(new Error('Only one instance of auth can happen at a time'));
+  Session.current = handler;
 };
 
 Session.onRedirectUri = function (url) {
-    if (Session.current(null, url)) {
-        Session.clean();
-    }
+  if (Session.current(null, url)) {
+    Session.clean();
+  }
 };
 
 module.exports = Session;


### PR DESCRIPTION
Fix issue #33 by deferring handling of closed/exit event on Android to see if a redirect URL comes through first. Without this change (or something similar), the consumer is not notified on Android if the user closes the InAppBrowser window.