### PR TITLE
Docs refer to client but it doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ const options = {
   scope: 'openid profile',
 };
 
-client.authorize(options, function (err, result) {
+auth0.authorize(options, function (err, result) {
   if (err) {
     // failure
   }


### PR DESCRIPTION
I don't want to step on any toes here and I'm totally new to this project but the example code doesn't seem to be right..  When I make the suggested change (in my PR) it works so...  Sorry if I missed something ..