### PR TITLE
Ensure Yarn is installed in CircleCI images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Update Yarn
-          command: 'sudo npm update -g yarn'
+          name: Install and Update Yarn
+          command: 'sudo npm install -y yarn && sudo npm update -g yarn'
       - restore-cache:
           name: Restore Yarn Package Cache
           keys:


### PR DESCRIPTION
This PR ensures Yarn is installed on the CircleCI image for testing. Trying to resolve the 'yarn: command not found' error currently being thrown on incoming PRs.