### PR TITLE
[SDK-3123] Fix failing CircleCI tests for yarn

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - checkout
       - run:
           name: Update Yarn
-          command: 'sudo npm update -g yarn'
+          command: 'npm install -g npm@latest && sudo npm install -g yarn@latest'
       - restore-cache:
           name: Restore Yarn Package Cache
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:lts-browsers
+      - image: cimg/node:lts-browsers
     environment:
       LANG: en_US.UTF-8
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - checkout
       - run:
           name: Update Yarn
-          command: 'sudo npm install -g npm@latest && sudo npm install -g yarn@latest'
+          command: 'sudo npm install -g npm@latest && sudo npm install -g --force yarn@latest'
       - restore-cache:
           name: Restore Yarn Package Cache
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - checkout
       - run:
           name: Update Yarn
-          command: 'npm install -g npm@latest && sudo npm install -g yarn@latest'
+          command: 'sudo npm install -g npm@latest && sudo npm install -g yarn@latest'
       - restore-cache:
           name: Restore Yarn Package Cache
           keys:


### PR DESCRIPTION
Uncertain why the `yarn` install has suddenly started failing on CircleCI images, have noticed others reporting it intermittently as well. In any event, this tweak ensures yarn is installed and available to the image for the tests to run successfully.