### PR TITLE
Remove step to install yarn

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,7 @@ jobs:
           command: |
             node -v
             npm -v
-      - run:
-          name: Update Yarn
-          command: npm install -g npm@latest && npm install -g --force yarn@latest
+            yarn -v
       - run:
           name: Install Dependencies
           command: yarn install


### PR DESCRIPTION
`yarn` is already part of the base image, but this step causes the build to fail thanks to a permissions error.

### Changes

Please describe both what is changing and why this is important. Include:

- Endpoints added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)
- Any alternative designs or approaches considered

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds test coverage
- [ ] This change has been tested on the latest compatible version of Cordova or why not

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
